### PR TITLE
fix: respect format query param in session export endpoint

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -258,9 +258,20 @@ export async function apiRoutes(fastify, options) {
 
   fastify.get('/api/sessions/:id/export', (request, reply) => {
     const { id } = request.params;
+    const { format } = request.query;
     const session = stmtSessionById.get(id);
     if (!session) return reply.code(404).send({ error: 'Session not found' });
     const events = stmtExportEvents.all(id);
+
+    if (format === 'csv') {
+      const header = 'tool_name,timestamp,duration_ms,exit_status,tool_summary\n';
+      const rows = events.map(e =>
+        `${e.tool_name ?? ''},${e.timestamp ?? ''},${e.duration_ms ?? ''},${e.exit_status ?? ''},${(e.tool_summary ?? '').replace(/"/g, '""')}`
+      ).join('\n');
+      reply.header('Content-Type', 'text/csv');
+      return reply.send(header + rows);
+    }
+
     reply.send({ session, events });
   });
 


### PR DESCRIPTION
## Summary
- Server was ignoring `format=csv` query parameter and always returning JSON
- Now properly serializes to CSV when requested and sets `Content-Type: text/csv` header

## Root Cause
`routes/api.js:257-263` — the export endpoint read `request.params.id` but never read `request.query.format`. It always called `reply.send({ session, events })` which serializes to JSON.

## Fix
- Read `request.query.format` from the request
- When `format=csv`, serialize events to CSV with proper header row
- Escape any quotes in tool_summary by doubling them (CSV standard)
- Set `Content-Type: text/csv` for CSV responses

## Test plan
- [ ] Go to History page
- [ ] Click CSV export on any session
- [ ] Verify downloaded file contains proper CSV with header row and comma-separated values
- [ ] Verify JSON export still works (default behavior)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)