### PR TITLE
fix: check HTTP status before downloading export data

### DIFF
--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -26,6 +26,11 @@ interface SessionSummary {
 
 async function exportSession(sessionId: string, format: 'jsonl' | 'csv') {
   const res = await fetch(`/api/sessions/${sessionId}/export?format=${format}`)
+  if (!res.ok) {
+    const error = await res.text()
+    alert(`Export failed: ${error}`)
+    return
+  }
   const text = await res.text()
   const blob = new Blob([text], {
     type: format === 'csv' ? 'text/csv' : 'application/x-ndjson',


### PR DESCRIPTION
## Summary
- Check `res.ok` before downloading export data
- Show user an alert with the error message instead of silently downloading error JSON as a data file

## Changes
- In `frontend/src/pages/HistoryPage.tsx`, check HTTP response status before triggering download

## Test plan
- [ ] Export a missing session ID — verify alert shows instead of silent download
- [ ] Trigger a server error during export — verify user sees error

🤖 Generated with [Claude Code](https://claude.com/claude-code)